### PR TITLE
all: use regexp compiler / templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ A policy based authorization library written in [Go](https://golang.org). Ships 
     description: "something humanly readable",
 
     // Who this policy affects. Supports RegExp
-    subjects: ["max", "peter", "zac|ken"],
+    subjects: ["max", "peter", "<zac|ken>"],
 
     // Can be allow or deny
     effect: "allow",
 
     // Which resources this policy affects. Supports RegExp
-    resources: ["urn:something:resource_a", "urn:something:resource_b", "urn:something:foo:.+"],
+    resources: ["urn:something:resource_a", "urn:something:resource_b", "urn:something:foo:<.+>"],
 
     // Which permissions this policy affects. Supports RegExp
-    permission: ["create|delete", "get"],
+    permission: ["<create|delete>", "get"],
 
     // Under which conditions this policy is active.
     conditions: [

--- a/guard/guard_test.go
+++ b/guard/guard_test.go
@@ -16,16 +16,16 @@ var conditions = map[string][]Condition{
 }
 
 var policies = []Policy{
-	&DefaultPolicy{"1", "description", []string{"zac"}, AllowAccess, []string{"articles:[0-9]+"}, []string{"create", "update", "foo|bar"}, nil},
-	&DefaultPolicy{"2", "description", []string{"zac"}, DenyAccess, []string{"articles:[0-9]+"}, []string{"create", "update"}, nil},
-	&DefaultPolicy{"3", "description", []string{}, AllowAccess, []string{"articles:[0-9]+"}, []string{"view"}, nil},
-	&DefaultPolicy{"4", "description", []string{"zac|anonymous"}, AllowAccess, []string{"articles:[0-9]+"}, []string{"view"}, nil},
-	&DefaultPolicy{"5", "subject is owner condition", []string{"zac"}, AllowAccess, []string{"articles:[0-9]+"}, []string{"create"}, conditions["sio"]},
-	&DefaultPolicy{"6", "subject is not owner condition", []string{"zac"}, AllowAccess, []string{"articles:[0-9]+"}, []string{"create"}, conditions["sino"]},
-	&DefaultPolicy{"7", "invalid condition", []string{"zac"}, AllowAccess, []string{"articles:[0-9]+"}, []string{"update"}, conditions["invalid"]},
-	&DefaultPolicy{"8", "invalid resource regex", []string{"zac"}, AllowAccess, []string{"[0-9+"}, []string{"update"}, nil},
-	&DefaultPolicy{"9", "invalid subject regex", []string{"[0-9+"}, AllowAccess, []string{"articles:[0-9]+"}, []string{"update"}, nil},
-	&DefaultPolicy{"10", "invalid permission regex", []string{"zac"}, AllowAccess, []string{"articles:[0-9]+"}, []string{"[0-9+"}, nil},
+	&DefaultPolicy{"1", "description", []string{"zac"}, AllowAccess, []string{"articles:<[0-9]+>"}, []string{"create", "update", "<foo|bar>"}, nil},
+	&DefaultPolicy{"2", "description", []string{"zac"}, DenyAccess, []string{"articles:<[0-9]+>"}, []string{"create", "update"}, nil},
+	&DefaultPolicy{"3", "description", []string{}, AllowAccess, []string{"articles:<[0-9]+>"}, []string{"view"}, nil},
+	&DefaultPolicy{"4", "description", []string{"<zac|anonymous>"}, AllowAccess, []string{"articles:<[0-9]+>"}, []string{"view"}, nil},
+	&DefaultPolicy{"5", "subject is owner condition", []string{"zac"}, AllowAccess, []string{"articles:<[0-9]+>"}, []string{"create"}, conditions["sio"]},
+	&DefaultPolicy{"6", "subject is not owner condition", []string{"zac"}, AllowAccess, []string{"articles:<[0-9]+>"}, []string{"create"}, conditions["sino"]},
+	&DefaultPolicy{"7", "invalid condition", []string{"zac"}, AllowAccess, []string{"articles:<[0-9]+>"}, []string{"update"}, conditions["invalid"]},
+	&DefaultPolicy{"8", "invalid resource regex", []string{"zac"}, AllowAccess, []string{"<[0-9+>"}, []string{"update"}, nil},
+	&DefaultPolicy{"9", "invalid subject regex", []string{"<[0-9+>"}, AllowAccess, []string{"articles:<[0-9]+>"}, []string{"update"}, nil},
+	&DefaultPolicy{"10", "invalid permission regex", []string{"zac"}, AllowAccess, []string{"articles:<[0-9]+>"}, []string{"<[0-9+>"}, nil},
 }
 
 var contexts = map[string]*Context{

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -25,6 +25,12 @@ type Policy interface {
 
 	// GetConditions returns the policies conditions.
 	GetConditions() []Condition
+
+	// GetStartDelimiter returns the delimiter which identifies the beginning of a regular expression
+	GetStartDelimiter() byte
+
+	// GetEndDelimiter returns the delimiter which identifies the end of a regular expression
+	GetEndDelimiter() byte
 }
 
 type DefaultPolicy struct {
@@ -67,4 +73,12 @@ func (p *DefaultPolicy) GetPermissions() []string {
 
 func (p *DefaultPolicy) GetConditions() []Condition {
 	return p.Conditions
+}
+
+func (p *DefaultPolicy) GetEndDelimiter() byte {
+	return '>'
+}
+
+func (p *DefaultPolicy) GetStartDelimiter() byte {
+	return '<'
 }

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -10,9 +10,9 @@ var conditions = []Condition{
 }
 
 var cases = []*DefaultPolicy{
-	{"1", "description", []string{"user"}, AllowAccess, []string{"articles:[0-9]+"}, []string{"create", "update"}, conditions},
-	{"2", "description", []string{"user"}, DenyAccess, []string{"articles:[0-9]+"}, []string{"create", "update"}, nil},
-	{"1", "description", []string{"user"}, "foobar", []string{"articles:[0-9]+"}, []string{"create", "update"}, conditions},
+	{"1", "description", []string{"user"}, AllowAccess, []string{"articles:<[0-9]+>"}, []string{"create", "update"}, conditions},
+	{"2", "description", []string{"user"}, DenyAccess, []string{"articles:<[0-9]+>"}, []string{"create", "update"}, nil},
+	{"1", "description", []string{"user"}, "foobar", []string{"articles:<[0-9]+>"}, []string{"create", "update"}, conditions},
 }
 
 func TestHasAccess(t *testing.T) {
@@ -30,5 +30,7 @@ func TestGetters(t *testing.T) {
 		assert.Equal(t, c.Conditions, c.GetConditions())
 		assert.Equal(t, c.Effect, c.GetEffect())
 		assert.Equal(t, c.Permissions, c.GetPermissions())
+		assert.Equal(t, byte('<'), c.GetStartDelimiter())
+		assert.Equal(t, byte('>'), c.GetEndDelimiter())
 	}
 }

--- a/policy/postgres/postgres_test.go
+++ b/policy/postgres/postgres_test.go
@@ -20,11 +20,11 @@ var conditions = []policy.Condition{
 
 var cases = []*policy.DefaultPolicy{
 	{"1", "description", []string{"user", "anonymous"}, policy.AllowAccess, []string{"article", "user"}, []string{"create", "update"}, conditions},
-	{"2", "description", []string{}, policy.AllowAccess, []string{"article|user"}, []string{"view"}, nil},
-	{"3", "description", []string{"peter|max"}, policy.DenyAccess, []string{"article", "user"}, []string{"view"}, conditions},
-	{"4", "description", []string{"user|max|anonymous", "peter"}, policy.DenyAccess, []string{".*"}, []string{"disable"}, conditions},
-	{"5", "description", []string{".*"}, policy.AllowAccess, []string{"article|user"}, []string{"view"}, conditions},
-	{"6", "description", []string{"us[er]+"}, policy.AllowAccess, []string{"article|user"}, []string{"view"}, conditions},
+	{"2", "description", []string{}, policy.AllowAccess, []string{"<article|user>"}, []string{"view"}, nil},
+	{"3", "description", []string{"<peter|max>"}, policy.DenyAccess, []string{"article", "user"}, []string{"view"}, conditions},
+	{"4", "description", []string{"<user|max|anonymous>", "peter"}, policy.DenyAccess, []string{".*"}, []string{"disable"}, conditions},
+	{"5", "description", []string{"<.*>"}, policy.AllowAccess, []string{"<article|user>"}, []string{"view"}, conditions},
+	{"6", "description", []string{"<us[er]+>"}, policy.AllowAccess, []string{"<article|user>"}, []string{"view"}, conditions},
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
Instead of handling subjects, permissions and resources as regular expression strings, Ladon now uses a regexp compiler which compiles templates to regular expressions: `urn:foo:bar:<[foo|bar]+>`