### PR TITLE
manager/rethink: Add NewRethinkManager.

### DIFF
--- a/manager_rethink.go
+++ b/manager_rethink.go
@@ -62,6 +62,22 @@ func rdbFromPolicy(p Policy) (*rdbSchema, error) {
 	}, err
 }
 
+// NewRethinkManager initializes a new RethinkManager for given session, table name defaults
+// to "policies".
+func NewRethinkManager(session *r.Session, table string) *RethinkManager {
+	if table == "" {
+		table = "policies"
+	}
+
+	policies := make(map[string]Policy)
+
+	return &RethinkManager{
+		Session:  session,
+		Table:    r.Table(table),
+		Policies: policies,
+	}
+}
+
 // RethinkManager is a rethinkdb implementation of Manager to store policies persistently.
 type RethinkManager struct {
 	Session *r.Session

--- a/manager_test.go
+++ b/manager_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ory-am/common/integration"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
-	r "gopkg.in/dancannon/gorethink.v2"
 )
 
 var managerPolicies = []*DefaultPolicy{
@@ -134,11 +133,7 @@ func connectMySQL() {
 
 func connectRDB() {
 	var session = integration.ConnectToRethinkDB("ladon", "policies")
-	rethinkManager = &RethinkManager{
-		Session:  session,
-		Table:    r.Table("policies"),
-		Policies: make(map[string]Policy),
-	}
+	rethinkManager = NewRethinkManager(session, "")
 
 	rethinkManager.Watch(context.Background())
 	time.Sleep(time.Second)


### PR DESCRIPTION
This commit makes using the RethinkManager consistent with SQL and Redis
Manager. Having a New[Implementation] making the code more self documented by make the API more idiomatic and making the requirement explicit.